### PR TITLE
Fix Fade-only check for star count greater than previous

### DIFF
--- a/as64core/route_loader.py
+++ b/as64core/route_loader.py
@@ -141,12 +141,11 @@ def validate_route(route):
         if type(split.star_count) != int:
             return "Split Star is not a valid integer"
 
-        if split.star_count < 0 or split.star_count > 120:
-            if split.split_type != SPLIT_FADE_ONLY:
+        if split.split_type != SPLIT_FADE_ONLY:
+            if split.star_count < 0 or split.star_count > 120:
                 return "Split: {} - Invalid Split Star.".format(split.title)
-
-        if split.star_count < prev_star_count:
-            return "Split: {} - Split star must be greater than previous split.".format(split.title)
+            if split.star_count < prev_star_count:
+                return "Split: {} - Split star must be greater than previous split.".format(split.title)
 
         prev_star_count = split.star_count
 


### PR DESCRIPTION
Currently, we can't set a split as Fade type because it requires the split to have more stars than the previous one.

![image](https://user-images.githubusercontent.com/7728178/127177365-1bf2c12b-6d2b-4c79-94f1-98566c111c5c.png)

As the Fade-only doesn't require a star count (it's the same as the last split), it's useless to check if the star count is greater than previous split.